### PR TITLE
feat: run cypress test suites as github workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,27 @@
+name: E2E
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: E2E
+    steps:
+      # We need to increase the amount of inotify watchers in order to prevent errors
+      # https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers#the-technical-details
+      - name: Setup
+        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: cypress-io/github-action@v2
+        with:
+          browser: chrome
+          headless: true
+          start: npm start
+          wait-on: 'http://localhost:8181'


### PR DESCRIPTION
## Describe the PR

This PR will introduces a Github Workflow to run all E2E Tests in Chrome Headless which will run on every _pull request_ and _after a merge_ on the main branch.

A had a little issue using the `live-server` implementation on `ubuntu-latest`. Every file system change resulted in an error:

```
Error: ENOSPC: System limit for number of file watchers reached
```

I was able to find a workaround by increasing the amount of inotify watchers. You can find a more detailed explanation here: https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers#the-technical-details

A preview of a successful test run is available here: https://github.com/gearsdigital/writer/actions/runs/176184061

## Related issues

<!-- PR relates to issues in the `writer` repo: -->

- Fixes #10

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Added in-code documentation (if needed)
